### PR TITLE
[codex] Add non-interactive flag selection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,8 +7,9 @@ PHP-DEL is a small PHP CLI tool that removes source code marked with
 Stylus. The package requires PHP 8.2 or newer and `ext-mbstring`.
 
 The CLI reads `php-del.json` from the current working directory, discovers
-flags in configured directories, asks the user to select one, then either
-rewrites matching files or deletes files carrying a matching `file` marker.
+flags in configured directories, selects one (interactively, or via `--flag`
+for non-interactive use), then either rewrites matching files or deletes files
+carrying a matching `file` marker.
 
 ## Common commands
 
@@ -18,6 +19,8 @@ composer test
 vendor/bin/phpunit
 ./php-del --help
 ./php-del --dry-run
+./php-del --list-flags
+./php-del --flag=<name>
 ```
 
 The repository also provides Docker/Task commands for the supported PHP
@@ -71,7 +74,8 @@ dependencies, or runtime behavior, preserve compatibility with all four.
 1. `Application` loads configuration through `ConfigFactory`.
 2. `Finder` scans configured directories and builds a unique, counted flag
    list plus the files containing relevant markers.
-3. CLImate prompts for one flag.
+3. The flag is resolved: `--flag` selects it non-interactively, `--list-flags`
+   prints the list and exits, otherwise CLImate prompts for one flag.
 4. Each target file is first checked by `Deleter` for a `file` marker.
 5. Otherwise, `CommentPatternProvider` chooses a pattern from the file name
    and `Rewriter` removes matching blocks and single lines.
@@ -96,6 +100,12 @@ dependencies, or runtime behavior, preserve compatibility with all four.
 - `php-del.json` defaults `extensions` to `["php"]`, but `dirs` is required.
 - Unknown rewrite extensions must continue to raise
   `UndefinedExtensionException`.
+- `--flag <name>` skips the prompt and is implicitly non-interactive; an
+  unknown flag must exit `1`. `--list-flags` prints names and counts, then
+  exits `0`. Decorative TTY output (`blink()`) is suppressed in these modes.
+- `main(): int` returns the exit code and `php-del` propagates it via
+  `exit()`. Only flag resolution affects the code (`0` success, `1` unknown
+  flag); per-file failures are reported but keep the overall code `0`.
 
 ## Change guidance
 
@@ -108,7 +118,10 @@ dependencies, or runtime behavior, preserve compatibility with all four.
 - Add or update both `tests/actual` and `tests/expect` fixtures for rewrite
   behavior. Add exception fixtures when validating malformed pairs.
 - Keep tests deterministic and non-interactive; test `Finder`, `Deleter`, and
-  `Rewriter` directly rather than driving the CLImate prompt.
+  `Rewriter` directly rather than driving the CLImate prompt. End-to-end CLI
+  behavior may be tested by running `php-del` as a subprocess with `--flag` /
+  `--list-flags` (see `tests/Unit/ApplicationE2ETest.php`), since those paths
+  never reach the prompt.
 - Do not edit `vendor/` or generated PHPUnit cache files.
 - Review `docs/releasing.md` when changing the PHP compatibility range or
   release process.

--- a/README.md
+++ b/README.md
@@ -5,10 +5,11 @@
 [![PHP Version Require](https://poser.pugx.org/kubotak-is/php-del/require/php)](https://packagist.org/packages/kubotak-is/php-del)
 [![License](https://poser.pugx.org/kubotak-is/php-del/license)](https://packagist.org/packages/kubotak-is/php-del)
 
-PHP-DEL is an interactive CLI tool that permanently removes source code
-marked with `php-del` comments. It is useful for maintaining optional,
-environment-specific, or temporary code paths and removing one selected
-feature before a release or deployment.
+PHP-DEL is a CLI tool that permanently removes source code marked with
+`php-del` comments. It runs interactively by default and offers a
+non-interactive mode (`--flag`) for CI and AI-agent automation. It is useful
+for maintaining optional, environment-specific, or temporary code paths and
+removing one selected feature before a release or deployment.
 
 ```php
 public function example(): void
@@ -91,7 +92,8 @@ examples.
    ```
 
 The command scans all configured files, counts each discovered flag, and
-prompts for one flag. It then processes every file containing that flag.
+prompts for one flag. It then processes every file containing that flag. To
+skip the prompt, pass `--flag=<name>` (see [Non-interactive Mode](#non-interactive-mode)).
 
 ## Marker Reference
 
@@ -161,12 +163,45 @@ For exact matching rules and format-specific examples, see
 ## CLI Options
 
 ```text
---dry-run  Discover and report changes without writing or deleting files
---help     Print the command usage
+--flag=<name>  Delete the given flag without the interactive prompt
+--list-flags   List discovered flags with their occurrence counts, then exit
+--dry-run      Discover and report changes without writing or deleting files
+--help         Print the command usage
 ```
 
-PHP-DEL currently selects flags interactively; there is no positional or
-non-interactive flag argument.
+When `--flag` is omitted, PHP-DEL prompts for a flag interactively. Passing
+`--flag` (or `--list-flags`) runs without any prompt, which makes it safe for
+CI pipelines and AI agents that have no interactive terminal.
+
+## Non-interactive Mode
+
+Specify the flag directly to skip the interactive prompt:
+
+```sh
+# List available flags first (machine-readable name and count)
+vendor/bin/php-del --list-flags
+
+# Delete a flag without prompting
+vendor/bin/php-del --flag=feature-a
+
+# Preview without writing or deleting
+vendor/bin/php-del --flag=feature-a --dry-run
+```
+
+If the given flag does not exist in the discovered list, PHP-DEL prints an
+error and exits with status `1` without modifying any file.
+
+### Exit Codes
+
+| Code | Meaning |
+| --- | --- |
+| `0` | Deletion completed, flags were listed, or no matching flag was found. |
+| `1` | A flag passed with `--flag` does not exist. |
+
+Per-file processing errors are reported and skipped; they do not change the
+overall exit code. Unhandled runtime errors (for example, a missing or invalid
+`php-del.json`) terminate the process with a non-zero status set by the PHP
+runtime.
 
 ## Safety
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -13,6 +13,9 @@ PHP-DEL overwrites and deletes files in place. Use this workflow:
 7. Inspect `git diff` and run the project's tests.
 8. Commit the generated source changes.
 
+In a non-interactive environment, replace the flag selection in steps 4 and 6
+with `--flag=<name>` (see [Non-interactive Selection](#non-interactive-selection)).
+
 ## Interactive Selection
 
 ```sh
@@ -31,8 +34,37 @@ Please choice me one of the following flag:
 The number is the count of discovered `start`, `line`, and `file` markers,
 not the number of files or final rewrite operations.
 
-The command currently requires an interactive terminal. A flag cannot be
-passed as a command-line argument.
+When no flag argument is given, the command requires an interactive terminal.
+Pass `--flag=<name>` to select a flag without the prompt (see
+[Non-interactive Selection](#non-interactive-selection)).
+
+## Non-interactive Selection
+
+Pass the target flag directly to skip the prompt. This is the recommended mode
+for CI pipelines and AI agents, where no interactive terminal is available:
+
+```sh
+vendor/bin/php-del --flag=legacy-api
+```
+
+If the given flag does not exist in the discovered list, the command prints an
+error and exits with status `1` without modifying any file.
+
+## Listing Flags
+
+List every discovered flag and its occurrence count, then exit without
+deleting anything:
+
+```sh
+vendor/bin/php-del --list-flags
+```
+
+```text
+flag-a (4)
+legacy-api (2)
+```
+
+Use this to discover which flags are available before choosing one to delete.
 
 ## Dry Run
 
@@ -67,6 +99,17 @@ Successful target files are displayed with one of these suffixes:
 
 Errors are reported per file and processing continues with the remaining
 target files.
+
+## Exit Codes
+
+| Code | Meaning |
+| --- | --- |
+| `0` | Deletion completed, flags were listed, or no matching flag was found. |
+| `1` | A flag passed with `--flag` does not exist. |
+
+Per-file errors are reported and skipped; they do not change the exit code.
+Unhandled runtime errors (for example, a missing or invalid `php-del.json`)
+terminate the process with a non-zero status set by the PHP runtime.
 
 ## Troubleshooting
 

--- a/php-del
+++ b/php-del
@@ -26,4 +26,4 @@ if (!defined('PHPDEL_COMPOSER_INSTALL')) {
 require PHPDEL_COMPOSER_INSTALL;
 
 $app = new PHPDel\Application(new \League\CLImate\CLImate());
-$app->main();
+exit($app->main());

--- a/src/Application.php
+++ b/src/Application.php
@@ -6,6 +6,7 @@ namespace PHPDel;
 use League\CLImate\CLImate;
 use PHPDel\Comment\CommentPatternProvider;
 use PHPDel\Factory\ConfigFactory;
+use PHPDel\Flag\FlagList;
 
 class Application
 {
@@ -17,6 +18,15 @@ class Application
     private function initCli(): void
     {
         $this->cli->arguments->add([
+            'flag' => [
+                'longPrefix'  => 'flag',
+                'description' => 'Specify the flag to delete without the interactive prompt',
+            ],
+            'list-flags' => [
+                'longPrefix'  => 'list-flags',
+                'description' => 'List detected flags and exit without deleting',
+                'noValue'     => true,
+            ],
             'dry-run' => [
                 'longPrefix'  => 'dry-run',
                 'description' => 'Make it work without executing delete',
@@ -41,25 +51,69 @@ class Application
         return (bool) $this->cli->arguments->get('dry-run');
     }
 
-    public function main(): void
+    private function isListFlags(): bool
+    {
+        return (bool) $this->cli->arguments->get('list-flags');
+    }
+
+    private function selectedFlag(): ?string
+    {
+        $flag = $this->cli->arguments->get('flag');
+
+        if ($flag === null || $flag === '') {
+            return null;
+        }
+
+        return (string) $flag;
+    }
+
+    private function hasSelectedFlagArgument(): bool
+    {
+        return $this->cli->arguments->defined('flag');
+    }
+
+    private function isNonInteractive(): bool
+    {
+        return $this->isListFlags() || $this->hasSelectedFlagArgument();
+    }
+
+    public function main(): int
     {
         if ($this->help()) {
             $this->cli->usage();
-            return;
+            return 0;
         }
         $config = ConfigFactory::make();
-        $this->cli->blink()->dim('Finding flag...');
+
+        if (!$this->isNonInteractive()) {
+            $this->cli->blink()->dim('Finding flag...');
+        }
         $finder = new Finder($config);
         $finder->findFlag();
         $flagList = $finder->getFlagList();
 
-        if ($flagList->empty()) {
-            $this->cli->backgroundYellow()->out("Nothing flag.");
-            return;
+        if ($this->isListFlags()) {
+            if ($flagList->empty()) {
+                $this->cli->backgroundYellow()->out("Nothing flag.");
+                return 0;
+            }
+
+            foreach ($flagList as $flag) {
+                $this->cli->out((string) $flag);
+            }
+            return 0;
         }
 
-        $input = $this->cli->radio('Please choice me one of the following flag:', (array) $flagList);
-        $deleteFlag = $input->prompt();
+        if (!$this->hasSelectedFlagArgument() && $flagList->empty()) {
+            $this->cli->backgroundYellow()->out("Nothing flag.");
+            return 0;
+        }
+
+        $deleteFlag = $this->resolveFlag($flagList);
+
+        if ($deleteFlag === null) {
+            return 1;
+        }
 
         foreach ($finder->getTargetFileList() as $file) {
             try {
@@ -93,6 +147,31 @@ class Application
             }
         }
         $this->cli->out("End php-del");
+
+        return 0;
+    }
+
+    private function resolveFlag(FlagList $flagList): ?string
+    {
+        $selected = $this->selectedFlag();
+
+        if ($this->hasSelectedFlagArgument()) {
+            if ($selected === null) {
+                $this->cli->error("[ERROR] The --flag option requires a value.");
+                return null;
+            }
+
+            if (!$flagList->has($selected)) {
+                $this->cli->error("[ERROR] The specified flag does not exist: {$selected}");
+                return null;
+            }
+
+            return $selected;
+        }
+
+        $input = $this->cli->radio('Please choice me one of the following flag:', (array) $flagList);
+
+        return $input->prompt();
     }
 
     private function readFile(string $file): string

--- a/src/Flag/FlagList.php
+++ b/src/Flag/FlagList.php
@@ -11,4 +11,9 @@ class FlagList extends ArrayIterator
     {
         return $this->count() === 0;
     }
+
+    public function has(string $flag): bool
+    {
+        return $this->offsetExists($flag);
+    }
 }

--- a/tests/Unit/ApplicationE2ETest.php
+++ b/tests/Unit/ApplicationE2ETest.php
@@ -1,0 +1,245 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * End-to-end tests that drive the real `php-del` executable as a subprocess.
+ *
+ * The non-interactive options (`--flag` / `--list-flags`) make this possible:
+ * because they never reach the CLImate `radio` prompt, the process runs to
+ * completion without stdin, so the whole pipeline — argument parsing, config
+ * loading, flag discovery, rewrite/delete, and the propagated exit code — can
+ * be exercised deterministically.
+ *
+ * Each test runs in an isolated temporary workspace so the repository's own
+ * `tests/actual` fixtures are never mutated.
+ */
+final class ApplicationE2ETest extends TestCase
+{
+    private string $workspace;
+
+    protected function setUp(): void
+    {
+        $base = sys_get_temp_dir() . '/php-del-e2e-' . uniqid('', true);
+
+        if (!mkdir($base . '/src', 0777, true) && !is_dir($base . '/src')) {
+            self::fail("Unable to create workspace: {$base}");
+        }
+
+        $this->workspace = $base;
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDir($this->workspace);
+    }
+
+    public function testHelpListsNonInteractiveOptions(): void
+    {
+        // `--help` returns before config loading, so no php-del.json is needed.
+        $result = $this->runCli(['--help']);
+
+        self::assertSame(0, $result['exit']);
+        self::assertStringContainsString('flag', $result['output']);
+        self::assertStringContainsString('list-flags', $result['output']);
+        self::assertStringContainsString('dry-run', $result['output']);
+    }
+
+    public function testListFlagsOutputsDetectedFlagsWithoutModifying(): void
+    {
+        $this->writeConfig();
+        $this->copyActual('flag_a/FlagA.php');
+        $this->copyActual('flag_b/FlagB.php');
+        $original = $this->read('FlagA.php');
+
+        $result = $this->runCli(['--list-flags']);
+
+        self::assertSame(0, $result['exit']);
+        self::assertStringContainsString('flag_a', $result['output']);
+        self::assertStringContainsString('flag_b', $result['output']);
+        // Listing must not touch any file.
+        self::assertSame($original, $this->read('FlagA.php'));
+    }
+
+    public function testFlagRewritesMatchingFile(): void
+    {
+        $this->writeConfig();
+        $this->copyActual('flag_a/FlagA.php');
+
+        $result = $this->runCli(['--flag=flag_a']);
+
+        self::assertSame(0, $result['exit']);
+        self::assertStringContainsString('End php-del', $result['output']);
+        self::assertSame(
+            file_get_contents(__DIR__ . '/../expect/flag_a/FlagA.php'),
+            $this->read('FlagA.php')
+        );
+    }
+
+    public function testDryRunDoesNotRewrite(): void
+    {
+        $this->writeConfig();
+        $this->copyActual('flag_a/FlagA.php');
+        $original = $this->read('FlagA.php');
+
+        $result = $this->runCli(['--flag=flag_a', '--dry-run']);
+
+        self::assertSame(0, $result['exit']);
+        self::assertSame($original, $this->read('FlagA.php'));
+    }
+
+    public function testFileFlagDeletesWholeFile(): void
+    {
+        $this->writeConfig();
+        $this->copyActual('delete_flag/DeleteFlag.php');
+
+        $result = $this->runCli(['--flag=delete_flag']);
+
+        self::assertSame(0, $result['exit']);
+        self::assertFileDoesNotExist($this->path('DeleteFlag.php'));
+    }
+
+    public function testDryRunDoesNotDeleteFile(): void
+    {
+        $this->writeConfig();
+        $this->copyActual('delete_flag/DeleteFlag.php');
+
+        $result = $this->runCli(['--flag=delete_flag', '--dry-run']);
+
+        self::assertSame(0, $result['exit']);
+        self::assertFileExists($this->path('DeleteFlag.php'));
+    }
+
+    public function testUnknownFlagExitsWithErrorCode(): void
+    {
+        $this->writeConfig();
+        $this->copyActual('flag_a/FlagA.php');
+        $original = $this->read('FlagA.php');
+
+        $result = $this->runCli(['--flag=does-not-exist']);
+
+        self::assertSame(1, $result['exit']);
+        self::assertStringContainsString('does not exist', $result['output']);
+        // A rejected flag must leave files untouched.
+        self::assertSame($original, $this->read('FlagA.php'));
+    }
+
+    public function testUnknownFlagExitsWithErrorCodeWhenNoMarkersFound(): void
+    {
+        $this->writeConfig();
+
+        $result = $this->runCli(['--flag=does-not-exist']);
+
+        self::assertSame(1, $result['exit']);
+        self::assertStringContainsString('does not exist', $result['output']);
+    }
+
+    public function testFlagWithoutValueExitsWithErrorCode(): void
+    {
+        $this->writeConfig();
+        $this->copyActual('flag_a/FlagA.php');
+        $original = $this->read('FlagA.php');
+
+        $result = $this->runCli(['--flag']);
+
+        self::assertSame(1, $result['exit']);
+        self::assertStringContainsString('requires a value', $result['output']);
+        self::assertSame($original, $this->read('FlagA.php'));
+    }
+
+    public function testReportsNothingWhenNoMarkersFound(): void
+    {
+        $this->writeConfig();
+        // Workspace src is empty: no markers to discover.
+
+        $result = $this->runCli(['--list-flags']);
+
+        self::assertSame(0, $result['exit']);
+        self::assertStringContainsString('Nothing flag', $result['output']);
+    }
+
+    /**
+     * Run the real php-del executable inside the workspace and capture output.
+     *
+     * @param list<string> $args
+     * @return array{exit:int,stdout:string,stderr:string,output:string}
+     */
+    private function runCli(array $args): array
+    {
+        $entry = realpath(__DIR__ . '/../../php-del');
+        self::assertNotFalse($entry, 'php-del executable not found');
+
+        $descriptors = [
+            0 => ['pipe', 'r'],
+            1 => ['pipe', 'w'],
+            2 => ['pipe', 'w'],
+        ];
+
+        $process = proc_open(
+            array_merge([PHP_BINARY, $entry], $args),
+            $descriptors,
+            $pipes,
+            $this->workspace
+        );
+        self::assertIsResource($process, 'failed to start php-del');
+
+        // Close stdin immediately so any unexpected prompt sees EOF instead of hanging.
+        fclose($pipes[0]);
+        $stdout = (string) stream_get_contents($pipes[1]);
+        $stderr = (string) stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        $exitCode = proc_close($process);
+
+        return [
+            'exit'   => $exitCode,
+            'stdout' => $stdout,
+            'stderr' => $stderr,
+            'output' => $stdout . $stderr,
+        ];
+    }
+
+    private function writeConfig(array $extensions = ['php']): void
+    {
+        file_put_contents(
+            $this->workspace . '/php-del.json',
+            (string) json_encode(['dirs' => ['src'], 'extensions' => $extensions], JSON_PRETTY_PRINT)
+        );
+    }
+
+    private function copyActual(string $relative, ?string $destName = null): void
+    {
+        $source = __DIR__ . '/../actual/' . $relative;
+        self::assertFileExists($source);
+        copy($source, $this->path($destName ?? basename($relative)));
+    }
+
+    private function path(string $name): string
+    {
+        return $this->workspace . '/src/' . $name;
+    }
+
+    private function read(string $name): string
+    {
+        return (string) file_get_contents($this->path($name));
+    }
+
+    private function removeDir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        $items = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($dir, FilesystemIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        foreach ($items as $item) {
+            $item->isDir() ? rmdir($item->getPathname()) : unlink($item->getPathname());
+        }
+
+        rmdir($dir);
+    }
+}

--- a/tests/Unit/FlagListTest.php
+++ b/tests/Unit/FlagListTest.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+use PHPDel\Flag\Flag;
+use PHPDel\Flag\FlagList;
+use PHPUnit\Framework\TestCase;
+
+final class FlagListTest extends TestCase
+{
+    public function testEmpty(): void
+    {
+        self::assertTrue((new FlagList([]))->empty());
+        self::assertFalse((new FlagList(['flag_a' => new Flag('flag_a')]))->empty());
+    }
+
+    public function testHas(): void
+    {
+        $list = new FlagList([
+            'flag_a'     => new Flag('flag_a'),
+            'error-flag' => new Flag('error-flag'),
+        ]);
+
+        self::assertTrue($list->has('flag_a'));
+        self::assertTrue($list->has('error-flag'));
+        self::assertFalse($list->has('unknown'));
+        self::assertFalse($list->has(''));
+    }
+}


### PR DESCRIPTION
## Summary

- add `--flag=<name>` to select a deletion flag without an interactive prompt
- add `--list-flags` to print discovered flags and occurrence counts without modifying files
- propagate application exit codes and reject unknown or missing flag values with status `1`
- document the non-interactive workflow and add end-to-end CLI coverage

## Why

The CLI previously required an interactive prompt, preventing deterministic use in CI pipelines and agent-driven workflows.

## Validation

- `task test-all`
- PHP 8.2, 8.3, 8.4, and 8.5: 34 tests, 122 assertions, all passing
- `git diff --check`