### PR TITLE
[codex] add marker validation and PHPStan

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -1,4 +1,4 @@
-name: Unit Test
+name: Quality Checks
 
 on:
   push:
@@ -8,6 +8,27 @@ permissions:
   contents: read
 
 jobs:
+  phpstan:
+    name: PHPStan
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Setup PHP 8.2
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          extensions: mbstring
+          tools: composer:v2
+          coverage: none
+
+      - name: Install dependencies
+        run: composer install --no-interaction --no-progress --prefer-dist
+
+      - name: Execute static analysis
+        run: composer analyse
+
   phpunit:
     name: PHP ${{ matrix.php-version }}
     runs-on: ubuntu-24.04

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup PHP 8.2
         uses: shivammathur/setup-php@v2
@@ -38,7 +38,7 @@ jobs:
         php-version: ['8.2', '8.3', '8.4', '8.5']
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup PHP ${{ matrix.php-version }}
         uses: shivammathur/setup-php@v2

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@ carrying a matching `file` marker.
 
 ```sh
 composer install
+composer analyse
 composer test
 vendor/bin/phpunit
 ./php-del --help
@@ -29,6 +30,7 @@ versions:
 
 ```sh
 task install
+task analyse
 task test
 task install-php82
 task test-php82
@@ -41,8 +43,9 @@ task test-php85
 task test-all
 ```
 
-CI runs `composer test` on PHP 8.2, 8.3, 8.4, and 8.5. When changing syntax,
-dependencies, or runtime behavior, preserve compatibility with all four.
+CI runs `composer analyse` on PHP 8.2 and `composer test` on PHP 8.2, 8.3,
+8.4, and 8.5. When changing syntax, dependencies, or runtime behavior,
+preserve compatibility with all four.
 
 ## Repository map
 
@@ -122,6 +125,7 @@ success, `1` for marker errors, or `2` when validation cannot complete.
 
 - Keep `declare(strict_types=1);`, the `PHPDel\` PSR-4 namespace, and the
   existing small-class organization.
+- Keep `composer analyse` passing at PHPStan level max and PHP 8.2.
 - Prefer extending `CommentPatternProvider` and adding a dedicated
   `CommentPattern` implementation when supporting a new file syntax.
 - Treat regular-expression changes as cross-format changes. Check raw PHP,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@ vendor/bin/phpunit
 ./php-del --dry-run
 ./php-del --list-flags
 ./php-del --flag=<name>
+./php-del --validate
 ```
 
 The repository also provides Docker/Task commands for the supported PHP
@@ -52,6 +53,9 @@ dependencies, or runtime behavior, preserve compatibility with all four.
   `<cwd>/php-del.json`.
 - `src/Finder.php`: recursively find configured extensions and aggregate
   `start`, `line`, and `file` flags.
+- `src/FileFinder.php`: enumerate configured files relative to `getcwd()`.
+- `src/Validation/`: scan comments and validate all marker structures without
+  modifying files.
 - `src/Rewriter.php`: repeatedly remove matching blocks and lines while
   preserving content enclosed by `ignore` markers.
 - `src/Deleter.php`: detect whole-file deletion markers.
@@ -82,6 +86,10 @@ dependencies, or runtime behavior, preserve compatibility with all four.
 6. Paired `ignore start`/`ignore end` content inside a deleted block is kept,
    but the ignore marker comments themselves are removed.
 
+With `--validate`, `Application` skips flag discovery and deletion, scans all
+configured files, prints position-based diagnostics, and returns `0` for
+success, `1` for marker errors, or `2` when validation cannot complete.
+
 ## Behavioral constraints
 
 - Supported markers are `start <flag>`, `end <flag>`, `line <flag>`,
@@ -105,7 +113,10 @@ dependencies, or runtime behavior, preserve compatibility with all four.
   exits `0`. Decorative TTY output (`blink()`) is suppressed in these modes.
 - `main(): int` returns the exit code and `php-del` propagates it via
   `exit()`. Only flag resolution affects the code (`0` success, `1` unknown
-  flag); per-file failures are reported but keep the overall code `0`.
+  flag) during normal deletion; per-file failures are reported but keep the
+  overall code `0`.
+- `--validate` must remain non-interactive and non-destructive. It cannot be
+  combined with `--flag`, `--list-flags`, or `--dry-run`.
 
 ## Change guidance
 
@@ -120,8 +131,8 @@ dependencies, or runtime behavior, preserve compatibility with all four.
 - Keep tests deterministic and non-interactive; test `Finder`, `Deleter`, and
   `Rewriter` directly rather than driving the CLImate prompt. End-to-end CLI
   behavior may be tested by running `php-del` as a subprocess with `--flag` /
-  `--list-flags` (see `tests/Unit/ApplicationE2ETest.php`), since those paths
-  never reach the prompt.
+  `--list-flags` / `--validate` (see `tests/Unit/ApplicationE2ETest.php`),
+  since those paths never reach the prompt.
 - Do not edit `vendor/` or generated PHPUnit cache files.
 - Review `docs/releasing.md` when changing the PHP compatibility range or
   release process.
@@ -137,3 +148,9 @@ afterward.
 
 `--dry-run` must not write or unlink files. Keep both rewrite and whole-file
 deletion paths covered when changing dry-run behavior.
+
+`--validate` must inspect all configured flags and must not write or unlink
+files under any outcome.
+
+The checked-in configuration includes malformed exception fixtures, so a
+repository-root `./php-del --validate` is expected to return `1`.

--- a/README.md
+++ b/README.md
@@ -252,12 +252,13 @@ The repository includes Docker environments for every supported PHP version:
 
 ```sh
 task install
+task analyse
 task test
 task test-all
 ```
 
 See [Development](docs/development.md) for individual PHP-version tasks,
-dependency updates, fixtures, and validation commands.
+static analysis, dependency updates, fixtures, and validation commands.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -166,12 +166,31 @@ For exact matching rules and format-specific examples, see
 --flag=<name>  Delete the given flag without the interactive prompt
 --list-flags   List discovered flags with their occurrence counts, then exit
 --dry-run      Discover and report changes without writing or deleting files
+--validate     Validate all php-del markers without modifying files
 --help         Print the command usage
 ```
 
 When `--flag` is omitted, PHP-DEL prompts for a flag interactively. Passing
-`--flag` (or `--list-flags`) runs without any prompt, which makes it safe for
-CI pipelines and AI agents that have no interactive terminal.
+`--flag`, `--list-flags`, and `--validate` run without any prompt, which makes
+them safe for CI pipelines and AI agents that have no interactive terminal.
+
+## Validation
+
+Validate every php-del marker in the configured files without selecting a
+flag or modifying any file:
+
+```sh
+vendor/bin/php-del --validate
+```
+
+Validation reports malformed flags, unknown marker commands, unmatched or
+crossing blocks, and invalid `ignore` placement with file, line, column, and
+diagnostic ID. It checks all configured files and flags, unlike `--dry-run`,
+which previews one selected flag.
+
+Validation exits with `0` when all markers are valid, `1` when marker errors
+are found, and `2` when validation cannot complete because of configuration,
+option, file access, or unsupported-extension errors.
 
 ## Non-interactive Mode
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -11,6 +11,11 @@ tasks:
     cmds:
       - docker compose run --rm php82 composer test
 
+  analyse:
+    desc: Run PHPStan with the minimum supported PHP version
+    cmds:
+      - docker compose run --rm php82 composer analyse
+
   install-php82:
     cmds:
       - docker compose run --rm php82 composer install

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,9 @@
     ],
     "license": ["MIT"],
     "scripts": {
+        "analyse": [
+            "phpstan analyse"
+        ],
         "test": [
             "phpunit"
         ]
@@ -34,6 +37,7 @@
         ]
     },
     "require-dev": {
+        "phpstan/phpstan": "^2.1",
         "phpunit/phpunit": "^11.5"
     },
     "config": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c24f0c246dc423e0d8eb9cdf5ca087bd",
+    "content-hash": "4bb4ce4d2e326f29b77978224960e027",
     "packages": [
         {
             "name": "league/climate",
@@ -414,6 +414,70 @@
                 "source": "https://github.com/phar-io/version/tree/3.2.1"
             },
             "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "2.2.2",
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e5cc34d491a90e79c216d824f60fe21fd4d93bd6",
+                "reference": "e5cc34d491a90e79c216d824f60fe21fd4d93bd6",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ondřej Mirtes"
+                },
+                {
+                    "name": "Markus Staab"
+                },
+                {
+                    "name": "Vincent Langlet"
+                }
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-06-05T09:00:01+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/docs/development.md
+++ b/docs/development.md
@@ -48,6 +48,25 @@ task test-php85
 
 CI runs the same suite on PHP 8.2, 8.3, 8.4, and 8.5.
 
+## Static Analysis
+
+Run PHPStan at the maximum rule level using the minimum supported PHP
+version:
+
+```sh
+task analyse
+```
+
+Equivalent command:
+
+```sh
+docker compose run --rm php82 composer analyse
+```
+
+PHPStan analyzes `src` and the `php-del` entry point. The configured PHP
+version is 8.2 so new code remains compatible with the minimum supported
+runtime.
+
 ## Composer Validation
 
 ```sh
@@ -111,6 +130,7 @@ If an applied run is necessary, use disposable fixture copies and verify
 ## Final Checks
 
 ```sh
+task analyse
 task test-all
 docker compose run --rm php82 composer validate --strict
 git diff --check

--- a/docs/development.md
+++ b/docs/development.md
@@ -100,6 +100,11 @@ Prefer unit tests. For manual verification:
 vendor/bin/php-del --dry-run
 ```
 
+The checked-in fixtures intentionally include malformed marker pairs, so
+running `vendor/bin/php-del --validate` against the repository's own
+`php-del.json` is expected to fail. Exercise validation through its unit and
+E2E tests or with a disposable configuration containing only valid fixtures.
+
 If an applied run is necessary, use disposable fixture copies and verify
 `git status` immediately afterward.
 

--- a/docs/markers.md
+++ b/docs/markers.md
@@ -119,6 +119,28 @@ php-del start feature-a
 Whitespace and line endings outside matched regions are otherwise preserved.
 PHP-DEL does not run a formatter after rewriting.
 
+## Validation
+
+Run the non-destructive validator before deletion or in CI:
+
+```sh
+vendor/bin/php-del --validate
+```
+
+It checks every configured file and flag. Validation rejects unmatched
+`start` / `end` and `ignore` pairs, nested blocks using the same flag,
+crossing blocks, `ignore` markers outside a deletion block, empty or invalid
+flags, and unknown php-del commands.
+
+Different flags may be nested only when they close in reverse order:
+
+```text
+php-del start outer
+php-del start inner
+php-del end inner
+php-del end outer
+```
+
 ## Format-Specific Syntax
 
 - [Blade templates](blade.md)

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -28,6 +28,7 @@ released as `2.0.0`.
 4. Run all supported PHP versions:
 
    ```sh
+   task analyse
    task test-all
    ```
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -79,6 +79,25 @@ Dry run performs discovery and rewrite calculation but does not:
 
 The output still labels matching files as rewrite or deletion targets.
 
+## Validation
+
+```sh
+vendor/bin/php-del --validate
+```
+
+Validation scans all configured files and flags without prompting, rewriting,
+or deleting. Diagnostics use this stable format:
+
+```text
+src/Legacy.php:18:5 [PDEL001] start "legacy" has no matching end
+```
+
+The command reports all readable-file errors before exiting. It detects
+invalid marker commands and flags, unmatched or crossing deletion blocks, and
+invalid `ignore` pairs or placement.
+
+Do not combine `--validate` with `--flag`, `--list-flags`, or `--dry-run`.
+
 ## Help
 
 ```sh
@@ -106,6 +125,14 @@ target files.
 | --- | --- |
 | `0` | Deletion completed, flags were listed, or no matching flag was found. |
 | `1` | A flag passed with `--flag` does not exist. |
+
+Validation uses:
+
+| Code | Meaning |
+| --- | --- |
+| `0` | All php-del markers are valid. |
+| `1` | One or more marker errors were found. |
+| `2` | Validation could not complete. |
 
 Per-file errors are reported and skipped; they do not change the exit code.
 Unhandled runtime errors (for example, a missing or invalid `php-del.json`)

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,6 @@
+parameters:
+    level: max
+    phpVersion: 80200
+    paths:
+        - src
+        - php-del

--- a/src/Application.php
+++ b/src/Application.php
@@ -7,6 +7,7 @@ use League\CLImate\CLImate;
 use PHPDel\Comment\CommentPatternProvider;
 use PHPDel\Factory\ConfigFactory;
 use PHPDel\Flag\FlagList;
+use PHPDel\Validation\ValidationRunner;
 
 class Application
 {
@@ -30,6 +31,11 @@ class Application
             'dry-run' => [
                 'longPrefix'  => 'dry-run',
                 'description' => 'Make it work without executing delete',
+                'noValue'     => true,
+            ],
+            'validate' => [
+                'longPrefix'  => 'validate',
+                'description' => 'Validate all php-del markers without modifying files',
                 'noValue'     => true,
             ],
             'help' => [
@@ -56,6 +62,11 @@ class Application
         return (bool) $this->cli->arguments->get('list-flags');
     }
 
+    private function isValidate(): bool
+    {
+        return (bool) $this->cli->arguments->get('validate');
+    }
+
     private function selectedFlag(): ?string
     {
         $flag = $this->cli->arguments->get('flag');
@@ -74,7 +85,7 @@ class Application
 
     private function isNonInteractive(): bool
     {
-        return $this->isListFlags() || $this->hasSelectedFlagArgument();
+        return $this->isListFlags() || $this->hasSelectedFlagArgument() || $this->isValidate();
     }
 
     public function main(): int
@@ -83,6 +94,11 @@ class Application
             $this->cli->usage();
             return 0;
         }
+
+        if ($this->isValidate()) {
+            return $this->validate();
+        }
+
         $config = ConfigFactory::make();
 
         if (!$this->isNonInteractive()) {
@@ -149,6 +165,42 @@ class Application
         $this->cli->out("End php-del");
 
         return 0;
+    }
+
+    private function validate(): int
+    {
+        if ($this->hasSelectedFlagArgument() || $this->isListFlags() || $this->isDryRun()) {
+            $this->cli->error(
+                '[ERROR] The --validate option cannot be combined with --flag, --list-flags, or --dry-run.'
+            );
+            return 2;
+        }
+
+        try {
+            $result = (new ValidationRunner(ConfigFactory::make()))->run();
+        } catch (\Throwable $throwable) {
+            $this->cli->error('[ERROR] ' . $throwable->getMessage());
+            return 2;
+        }
+
+        foreach ($result->diagnostics as $diagnostic) {
+            $this->cli->error((string) $diagnostic);
+        }
+
+        if ($result->diagnostics === []) {
+            $this->cli->out(
+                "php-del validation passed: {$result->fileCount} files, {$result->markerCount} markers"
+            );
+            return 0;
+        }
+
+        $errorCount = count($result->diagnostics);
+        $errorFileCount = $result->errorFileCount();
+        $this->cli->out(
+            "php-del validation failed: {$errorCount} errors in {$errorFileCount} files"
+        );
+
+        return $result->exitCode();
     }
 
     private function resolveFlag(FlagList $flagList): ?string

--- a/src/Application.php
+++ b/src/Application.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace PHPDel;
 
 use League\CLImate\CLImate;
+use League\CLImate\TerminalObject\Dynamic\Radio;
 use PHPDel\Comment\CommentPatternProvider;
 use PHPDel\Factory\ConfigFactory;
 use PHPDel\Flag\FlagList;
@@ -71,11 +72,11 @@ class Application
     {
         $flag = $this->cli->arguments->get('flag');
 
-        if ($flag === null || $flag === '') {
+        if (!is_string($flag) || $flag === '') {
             return null;
         }
 
-        return (string) $flag;
+        return $flag;
     }
 
     private function hasSelectedFlagArgument(): bool
@@ -222,6 +223,10 @@ class Application
         }
 
         $input = $this->cli->radio('Please choice me one of the following flag:', (array) $flagList);
+
+        if (!$input instanceof Radio) {
+            throw new \RuntimeException('Unable to create flag selection prompt.');
+        }
 
         return $input->prompt();
     }

--- a/src/Comment/IgnoreComment.php
+++ b/src/Comment/IgnoreComment.php
@@ -23,6 +23,11 @@ class IgnoreComment extends SandWitchComment
     private function endPositionWithCode(): int
     {
         $erasedEnd = mb_strstr($this->targetCode(), $this->endPhrase, true);
+
+        if ($erasedEnd === false) {
+            throw new \RuntimeException('Unable to locate ignore end comment.');
+        }
+
         $eol = mb_strrpos($erasedEnd, PHP_EOL);
         return $eol === false ? mb_strlen($erasedEnd) : $eol;
     }

--- a/src/Comment/LineComment.php
+++ b/src/Comment/LineComment.php
@@ -34,7 +34,13 @@ class LineComment extends Comment
 
     private function setStartPosition(): void
     {
-        $this->startPosition = (int) mb_strrpos(mb_strstr($this->target, $this->phrase, true), PHP_EOL);
+        $targetBefore = mb_strstr($this->target, $this->phrase, true);
+
+        if ($targetBefore === false) {
+            throw new \RuntimeException('Unable to locate line comment.');
+        }
+
+        $this->startPosition = (int) mb_strrpos($targetBefore, PHP_EOL);
     }
 
     private function setEndPosition(): void

--- a/src/Comment/SandWitchComment.php
+++ b/src/Comment/SandWitchComment.php
@@ -51,7 +51,7 @@ abstract class SandWitchComment extends Comment
         if (!$this->foundStart && $this->foundEnd) {
             throw new SandWitchCommentException("There is an end comment, but no start.");
         }
-        $this->found = $this->foundStart && $this->foundEnd;
+        $this->found = $this->foundStart;
     }
 
     protected function setStartPosition(): void
@@ -63,12 +63,24 @@ abstract class SandWitchComment extends Comment
         $fromLettersUpToPhpEolToComments = mb_substr($this->target, $charUpToPhpEolPosition, mb_strlen($targetBefore) - $charUpToPhpEolPosition);
         // (B)に改行および空白文字以外が存在するかチェック
         $charOtherThanPhpEol = mb_strlen(trim($fromLettersUpToPhpEolToComments, " \t\n\r"));
-        $this->startPosition = $charOtherThanPhpEol === 0 ? $charUpToPhpEolPosition : mb_strpos($this->target, $this->startPhrase);
+        $startPosition = mb_strpos($this->target, $this->startPhrase);
+
+        if ($startPosition === false) {
+            throw new \RuntimeException('Unable to locate start comment.');
+        }
+
+        $this->startPosition = $charOtherThanPhpEol === 0 ? $charUpToPhpEolPosition : $startPosition;
     }
 
     protected function setEndPosition(): void
     {
-        $this->endPosition = mb_strpos($this->target, $this->endPhrase) + mb_strlen($this->endPhrase);
+        $endPosition = mb_strpos($this->target, $this->endPhrase);
+
+        if ($endPosition === false) {
+            throw new \RuntimeException('Unable to locate end comment.');
+        }
+
+        $this->endPosition = $endPosition + mb_strlen($this->endPhrase);
     }
 
     abstract protected function matchStartPattern(): string;

--- a/src/Config.php
+++ b/src/Config.php
@@ -5,32 +5,58 @@ namespace PHPDel;
 
 readonly class Config
 {
+    /** @var list<string> */
     private array $dirs;
+
+    /** @var list<string> */
     private array $extensions;
 
+    /**
+     * @param array<array-key, mixed> $config
+     */
     public function __construct(array $config)
     {
-        $this->validate($config);
-        $this->dirs = $config['dirs'];
-        $this->extensions = $config['extensions'] ?? ['php'];
+        $this->dirs = $this->stringList($config['dirs'] ?? null, 'dirs');
+        $this->extensions = array_key_exists('extensions', $config)
+            ? $this->stringList($config['extensions'], 'extensions')
+            : ['php'];
     }
 
-    private function validate(array $config): void
+    /**
+     * @return list<string>
+     */
+    private function stringList(mixed $value, string $name): array
     {
-        if (!isset($config['dirs']) || !is_array($config['dirs'])) {
-            throw new \InvalidArgumentException('The "dirs" configuration must be an array.');
+        if (!is_array($value)) {
+            throw new \InvalidArgumentException("The \"{$name}\" configuration must be an array.");
         }
 
-        if (isset($config['extensions']) && !is_array($config['extensions'])) {
-            throw new \InvalidArgumentException('The "extensions" configuration must be an array.');
+        $values = [];
+
+        foreach ($value as $item) {
+            if (!is_string($item)) {
+                throw new \InvalidArgumentException(
+                    "The \"{$name}\" configuration must contain only strings."
+                );
+            }
+
+            $values[] = $item;
         }
+
+        return $values;
     }
 
+    /**
+     * @return list<string>
+     */
     public function getDirs(): array
     {
         return $this->dirs;
     }
 
+    /**
+     * @return list<string>
+     */
     public function getExtensions(): array
     {
         return $this->extensions;

--- a/src/Factory/ConfigFactory.php
+++ b/src/Factory/ConfigFactory.php
@@ -17,7 +17,16 @@ class ConfigFactory
         }
 
         $json = mb_convert_encoding($json, 'UTF8', 'ASCII,JIS,UTF-8,EUC-JP,SJIS-WIN');
+
+        if ($json === false) {
+            throw new \RuntimeException("Unable to convert configuration encoding: {$path}");
+        }
+
         $arr = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+
+        if (!is_array($arr)) {
+            throw new \InvalidArgumentException('The configuration root must be an object.');
+        }
 
         return new Config($arr);
     }

--- a/src/File/FileList.php
+++ b/src/File/FileList.php
@@ -5,6 +5,9 @@ namespace PHPDel\File;
 
 use ArrayIterator;
 
+/**
+ * @extends ArrayIterator<int, string>
+ */
 class FileList extends ArrayIterator
 {
 }

--- a/src/FileFinder.php
+++ b/src/FileFinder.php
@@ -24,6 +24,10 @@ readonly class FileFinder
         return new AllFileList($files);
     }
 
+    /**
+     * @param list<string> $extensions
+     * @param list<string> $results
+     */
     private function rglob(string $dir, array $extensions, array &$results): void
     {
         $items = glob($dir);

--- a/src/FileFinder.php
+++ b/src/FileFinder.php
@@ -1,0 +1,52 @@
+<?php
+declare(strict_types=1);
+
+namespace PHPDel;
+
+use PHPDel\File\AllFileList;
+
+readonly class FileFinder
+{
+    public function __construct(private Config $config)
+    {
+    }
+
+    public function find(): AllFileList
+    {
+        $files = [];
+
+        foreach ($this->config->getDirs() as $dir) {
+            $directoryFiles = [];
+            $this->rglob(getcwd() . '/' . $dir, $this->config->getExtensions(), $directoryFiles);
+            $files = [...$directoryFiles, ...$files];
+        }
+
+        return new AllFileList($files);
+    }
+
+    private function rglob(string $dir, array $extensions, array &$results): void
+    {
+        $items = glob($dir);
+
+        if ($items === false) {
+            return;
+        }
+
+        foreach ($items as $item) {
+            if (is_dir($item)) {
+                $this->rglob($item . '/*', $extensions, $results);
+                continue;
+            }
+
+            if (!is_file($item)) {
+                continue;
+            }
+
+            $extension = pathinfo($item, PATHINFO_EXTENSION);
+
+            if (in_array($extension, $extensions, true)) {
+                $results[] = $item;
+            }
+        }
+    }
+}

--- a/src/Finder.php
+++ b/src/Finder.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace PHPDel;
 
-use PHPDel\File\{AllFileList,TargetFileList};
+use PHPDel\File\{AllFileList, TargetFileList};
 use PHPDel\Flag\{Flag,FlagList,FlagManager};
 
 class Finder
@@ -14,7 +14,7 @@ class Finder
 
     public function __construct(private readonly Config $config)
     {
-        $this->setAllFileList();
+        $this->allFileList = (new FileFinder($this->config))->find();
     }
 
     public function findFlag(): void
@@ -60,50 +60,4 @@ class Finder
         return $this->flagList;
     }
 
-    private function setAllFileList(): void
-    {
-        $this->allFileList = $this->getAllFileList($this->config->getDirs());
-    }
-
-    private function getAllFileList(array $dirs): AllFileList
-    {
-        $files = [];
-
-        foreach ($dirs as $dir) {
-            $files = [...$this->getFiles($dir, $this->config), ...$files];
-        }
-
-        return new AllFileList($files);
-    }
-
-    private function getFiles(string $dir, Config $config): array
-    {
-        $files = [];
-        $this->rglob(getcwd(). '/' . $dir, $config->getExtensions(), $files);
-
-        return $files;
-    }
-
-    private function rglob(string $dir, array $exts, array &$results = []): void
-    {
-        $ls = glob($dir);
-
-        if ($ls === false) {
-            return;
-        }
-
-        foreach ($ls as $item) {
-            if (is_dir($item)) {
-                $this->rglob($item . '/*', $exts, $results);
-            }
-
-            if (is_file($item)) {
-                $ext = pathinfo($item, PATHINFO_EXTENSION);
-
-                if (in_array($ext, $exts, true)) {
-                    $results[] = $item;
-                }
-            }
-        }
-    }
 }

--- a/src/Flag/FlagList.php
+++ b/src/Flag/FlagList.php
@@ -5,6 +5,9 @@ namespace PHPDel\Flag;
 
 use ArrayIterator;
 
+/**
+ * @extends ArrayIterator<string, Flag>
+ */
 class FlagList extends ArrayIterator
 {
     public function empty(): bool

--- a/src/Flag/FlagManager.php
+++ b/src/Flag/FlagManager.php
@@ -5,6 +5,7 @@ namespace PHPDel\Flag;
 
 class FlagManager
 {
+    /** @var array<string, Flag> */
     private array $hasMap = [];
 
     public function add(Flag $flag): void

--- a/src/Validation/Diagnostic.php
+++ b/src/Validation/Diagnostic.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+namespace PHPDel\Validation;
+
+readonly class Diagnostic
+{
+    public function __construct(
+        public string $path,
+        public int $line,
+        public int $column,
+        public string $id,
+        public string $message,
+        public bool $runtimeError = false,
+    ) {
+    }
+
+    public function __toString(): string
+    {
+        return "{$this->path}:{$this->line}:{$this->column} [{$this->id}] {$this->message}";
+    }
+}

--- a/src/Validation/Marker.php
+++ b/src/Validation/Marker.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace PHPDel\Validation;
+
+readonly class Marker
+{
+    public const START = 'start';
+    public const END = 'end';
+    public const LINE = 'line';
+    public const FILE = 'file';
+    public const IGNORE_START = 'ignore-start';
+    public const IGNORE_END = 'ignore-end';
+    public const INVALID = 'invalid';
+
+    public function __construct(
+        public string $type,
+        public ?string $flag,
+        public int $line,
+        public int $column,
+        public int $offset,
+        public ?string $errorId = null,
+        public ?string $errorMessage = null,
+    ) {
+    }
+}

--- a/src/Validation/MarkerScanner.php
+++ b/src/Validation/MarkerScanner.php
@@ -1,0 +1,169 @@
+<?php
+declare(strict_types=1);
+
+namespace PHPDel\Validation;
+
+use PHPDel\Exception\UndefinedExtensionException;
+
+class MarkerScanner
+{
+    /**
+     * @return list<Marker>
+     */
+    public function scan(string $filePath, string $text): array
+    {
+        $comments = $this->comments($filePath, $text);
+        $markers = [];
+
+        foreach ($comments as [$comment, $commentOffset]) {
+            $matches = [];
+            $result = preg_match_all('/php-del/iu', $comment, $matches, PREG_OFFSET_CAPTURE);
+
+            if ($result === false || $result === 0) {
+                continue;
+            }
+
+            foreach ($matches[0] as $match) {
+                $offset = $commentOffset + $match[1];
+                [$line, $column] = $this->position($text, $offset);
+                $tail = mb_substr($comment, $this->byteOffsetToCharacterOffset($comment, $match[1]));
+                $markers[] = $this->parse($tail, $line, $column, $offset);
+            }
+        }
+
+        usort($markers, static fn (Marker $a, Marker $b): int => $a->offset <=> $b->offset);
+
+        return $markers;
+    }
+
+    /**
+     * @return list<array{string, int}>
+     */
+    private function comments(string $filePath, string $text): array
+    {
+        if (str_ends_with($filePath, '.blade.php')) {
+            return $this->regexComments('/{{--.*?--}}/su', $text);
+        }
+
+        return match (pathinfo($filePath, PATHINFO_EXTENSION)) {
+            'php' => $this->phpComments($text),
+            'css' => $this->regexComments('/\/\*.*?\*\//su', $text),
+            'sass', 'scss', 'stylus' => $this->regexComments('/\/\*.*?\*\/|\/\/[^\r\n]*/su', $text),
+            default => throw new UndefinedExtensionException(
+                pathinfo($filePath, PATHINFO_EXTENSION) . ' is undefined extension.'
+            ),
+        };
+    }
+
+    /**
+     * @return list<array{string, int}>
+     */
+    private function phpComments(string $text): array
+    {
+        $comments = [];
+        $offset = 0;
+
+        foreach (token_get_all($text) as $token) {
+            $tokenText = is_array($token) ? $token[1] : $token;
+
+            if (is_array($token) && in_array($token[0], [T_COMMENT, T_DOC_COMMENT], true)) {
+                $comments[] = [$tokenText, $offset];
+            }
+
+            $offset += strlen($tokenText);
+        }
+
+        return $comments;
+    }
+
+    /**
+     * @return list<array{string, int}>
+     */
+    private function regexComments(string $pattern, string $text): array
+    {
+        $matches = [];
+        $result = preg_match_all($pattern, $text, $matches, PREG_OFFSET_CAPTURE);
+
+        if ($result === false || $result === 0) {
+            return [];
+        }
+
+        return $matches[0];
+    }
+
+    private function parse(string $tail, int $line, int $column, int $offset): Marker
+    {
+        $body = mb_substr($tail, mb_strlen('php-del'));
+        $body = (string) preg_replace('/(?:\*\/|--}})\s*$/u', '', $body);
+        $body = (string) preg_replace('/(?:^|\R)[ \t]*\*[ \t]?/u', '$1', $body);
+        $tokens = preg_split('/[ \t　\r\n]+/u', trim($body));
+        $tokens = $tokens === false ? [] : array_values(array_filter($tokens, static fn (string $v): bool => $v !== ''));
+        $command = isset($tokens[0]) ? mb_strtolower($tokens[0]) : '';
+
+        if ($command === 'ignore') {
+            $side = isset($tokens[1]) ? mb_strtolower($tokens[1]) : '';
+
+            if ($side === 'start') {
+                return new Marker(Marker::IGNORE_START, null, $line, $column, $offset);
+            }
+
+            if ($side === 'end') {
+                return new Marker(Marker::IGNORE_END, null, $line, $column, $offset);
+            }
+
+            return $this->invalid($line, $column, $offset, 'PDEL011', 'unknown php-del marker');
+        }
+
+        if (!in_array($command, [Marker::START, Marker::END, Marker::LINE, Marker::FILE], true)) {
+            return $this->invalid($line, $column, $offset, 'PDEL011', 'unknown php-del marker');
+        }
+
+        $flag = $tokens[1] ?? '';
+
+        if ($flag === '') {
+            return $this->invalid($line, $column, $offset, 'PDEL005', 'marker requires a flag');
+        }
+
+        if (preg_match('/\A[a-z0-9_\-=]+\z/iu', $flag) !== 1) {
+            return $this->invalid($line, $column, $offset, 'PDEL006', "invalid flag \"{$flag}\"");
+        }
+
+        return new Marker($command, $flag, $line, $column, $offset);
+    }
+
+    private function invalid(
+        int $line,
+        int $column,
+        int $offset,
+        string $errorId,
+        string $errorMessage
+    ): Marker {
+        return new Marker(
+            Marker::INVALID,
+            null,
+            $line,
+            $column,
+            $offset,
+            $errorId,
+            $errorMessage
+        );
+    }
+
+    /**
+     * @return array{int, int}
+     */
+    private function position(string $text, int $offset): array
+    {
+        $before = substr($text, 0, $offset);
+        $line = substr_count($before, "\n") + 1;
+        $lastNewline = strrpos($before, "\n");
+        $lineText = $lastNewline === false ? $before : substr($before, $lastNewline + 1);
+
+        return [$line, mb_strlen($lineText) + 1];
+    }
+
+    private function byteOffsetToCharacterOffset(string $text, int $byteOffset): int
+    {
+        return mb_strlen(substr($text, 0, $byteOffset));
+    }
+}

--- a/src/Validation/ValidationResult.php
+++ b/src/Validation/ValidationResult.php
@@ -1,0 +1,39 @@
+<?php
+declare(strict_types=1);
+
+namespace PHPDel\Validation;
+
+readonly class ValidationResult
+{
+    /**
+     * @param list<Diagnostic> $diagnostics
+     */
+    public function __construct(
+        public array $diagnostics,
+        public int $fileCount,
+        public int $markerCount,
+    ) {
+    }
+
+    public function exitCode(): int
+    {
+        foreach ($this->diagnostics as $diagnostic) {
+            if ($diagnostic->runtimeError) {
+                return 2;
+            }
+        }
+
+        return $this->diagnostics === [] ? 0 : 1;
+    }
+
+    public function errorFileCount(): int
+    {
+        $files = [];
+
+        foreach ($this->diagnostics as $diagnostic) {
+            $files[$diagnostic->path] = true;
+        }
+
+        return count($files);
+    }
+}

--- a/src/Validation/ValidationRunner.php
+++ b/src/Validation/ValidationRunner.php
@@ -1,0 +1,68 @@
+<?php
+declare(strict_types=1);
+
+namespace PHPDel\Validation;
+
+use PHPDel\Config;
+use PHPDel\Exception\UndefinedExtensionException;
+use PHPDel\FileFinder;
+
+readonly class ValidationRunner
+{
+    public function __construct(
+        private Config $config,
+        private MarkerScanner $scanner = new MarkerScanner(),
+        private Validator $validator = new Validator(),
+    ) {
+    }
+
+    public function run(): ValidationResult
+    {
+        $files = iterator_to_array((new FileFinder($this->config))->find(), false);
+        sort($files, SORT_STRING);
+        $diagnostics = [];
+        $markerCount = 0;
+
+        foreach ($files as $file) {
+            $path = $this->relativePath($file);
+            $text = file_get_contents($file);
+
+            if ($text === false) {
+                $diagnostics[] = new Diagnostic(
+                    $path,
+                    1,
+                    1,
+                    'PDEL013',
+                    'unable to read file',
+                    true
+                );
+                continue;
+            }
+
+            try {
+                $markers = $this->scanner->scan($file, $text);
+                $markerCount += count($markers);
+                array_push($diagnostics, ...$this->validator->validate($path, $markers));
+            } catch (UndefinedExtensionException) {
+                $extension = pathinfo($file, PATHINFO_EXTENSION);
+                $diagnostics[] = new Diagnostic(
+                    $path,
+                    1,
+                    1,
+                    'PDEL012',
+                    "extension \"{$extension}\" is not supported",
+                    true
+                );
+            }
+        }
+
+        return new ValidationResult($diagnostics, count($files), $markerCount);
+    }
+
+    private function relativePath(string $path): string
+    {
+        $cwd = rtrim((string) getcwd(), DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+
+        return str_starts_with($path, $cwd) ? substr($path, strlen($cwd)) : $path;
+    }
+}

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -53,8 +53,10 @@ class Validator
                     continue;
                 }
 
-                if ($index !== array_key_last($blocks)) {
-                    $top = $blocks[array_key_last($blocks)];
+                $lastIndex = array_key_last($blocks);
+
+                if ($lastIndex !== null && $index !== $lastIndex) {
+                    $top = $blocks[$lastIndex];
                     $diagnostics[] = $this->diagnostic(
                         $path,
                         $marker,

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -1,0 +1,170 @@
+<?php
+declare(strict_types=1);
+
+namespace PHPDel\Validation;
+
+class Validator
+{
+    /**
+     * @param list<Marker> $markers
+     * @return list<Diagnostic>
+     */
+    public function validate(string $path, array $markers): array
+    {
+        $diagnostics = [];
+        $blocks = [];
+        $ignores = [];
+
+        foreach ($markers as $marker) {
+            if ($marker->type === Marker::INVALID) {
+                $diagnostics[] = $this->diagnostic(
+                    $path,
+                    $marker,
+                    (string) $marker->errorId,
+                    (string) $marker->errorMessage
+                );
+                continue;
+            }
+
+            if ($marker->type === Marker::START) {
+                if ($this->containsFlag($blocks, (string) $marker->flag)) {
+                    $diagnostics[] = $this->diagnostic(
+                        $path,
+                        $marker,
+                        'PDEL003',
+                        "nested block for \"{$marker->flag}\" is not supported"
+                    );
+                }
+
+                $blocks[] = $marker;
+                continue;
+            }
+
+            if ($marker->type === Marker::END) {
+                $index = $this->lastFlagIndex($blocks, (string) $marker->flag);
+
+                if ($index === null) {
+                    $diagnostics[] = $this->diagnostic(
+                        $path,
+                        $marker,
+                        'PDEL002',
+                        "end \"{$marker->flag}\" has no matching start"
+                    );
+                    continue;
+                }
+
+                if ($index !== array_key_last($blocks)) {
+                    $top = $blocks[array_key_last($blocks)];
+                    $diagnostics[] = $this->diagnostic(
+                        $path,
+                        $marker,
+                        'PDEL004',
+                        "block \"{$marker->flag}\" closes before nested block \"{$top->flag}\""
+                    );
+                }
+
+                array_splice($blocks, $index, 1);
+                continue;
+            }
+
+            if ($marker->type === Marker::IGNORE_START) {
+                if ($blocks === []) {
+                    $diagnostics[] = $this->diagnostic(
+                        $path,
+                        $marker,
+                        'PDEL009',
+                        'ignore markers must be inside a delete block'
+                    );
+                }
+
+                if ($ignores !== []) {
+                    $diagnostics[] = $this->diagnostic(
+                        $path,
+                        $marker,
+                        'PDEL010',
+                        'nested ignore block is not supported'
+                    );
+                }
+
+                $ignores[] = $marker;
+                continue;
+            }
+
+            if ($marker->type === Marker::IGNORE_END) {
+                if ($blocks === []) {
+                    $diagnostics[] = $this->diagnostic(
+                        $path,
+                        $marker,
+                        'PDEL009',
+                        'ignore markers must be inside a delete block'
+                    );
+                }
+
+                if ($ignores === []) {
+                    $diagnostics[] = $this->diagnostic(
+                        $path,
+                        $marker,
+                        'PDEL008',
+                        'ignore end has no matching start'
+                    );
+                    continue;
+                }
+
+                array_pop($ignores);
+            }
+        }
+
+        foreach ($blocks as $marker) {
+            $diagnostics[] = $this->diagnostic(
+                $path,
+                $marker,
+                'PDEL001',
+                "start \"{$marker->flag}\" has no matching end"
+            );
+        }
+
+        foreach ($ignores as $marker) {
+            $diagnostics[] = $this->diagnostic(
+                $path,
+                $marker,
+                'PDEL007',
+                'ignore start has no matching end'
+            );
+        }
+
+        usort(
+            $diagnostics,
+            static fn (Diagnostic $a, Diagnostic $b): int => [$a->line, $a->column, $a->id]
+                <=> [$b->line, $b->column, $b->id]
+        );
+
+        return $diagnostics;
+    }
+
+    /**
+     * @param list<Marker> $blocks
+     */
+    private function containsFlag(array $blocks, string $flag): bool
+    {
+        return $this->lastFlagIndex($blocks, $flag) !== null;
+    }
+
+    /**
+     * @param list<Marker> $blocks
+     */
+    private function lastFlagIndex(array $blocks, string $flag): ?int
+    {
+        for ($index = count($blocks) - 1; $index >= 0; --$index) {
+            if (strcasecmp((string) $blocks[$index]->flag, $flag) === 0) {
+                return $index;
+            }
+        }
+
+        return null;
+    }
+
+    private function diagnostic(string $path, Marker $marker, string $id, string $message): Diagnostic
+    {
+        return new Diagnostic($path, $marker->line, $marker->column, $id, $message);
+    }
+}

--- a/tests/Unit/ApplicationE2ETest.php
+++ b/tests/Unit/ApplicationE2ETest.php
@@ -44,6 +44,7 @@ final class ApplicationE2ETest extends TestCase
         self::assertStringContainsString('flag', $result['output']);
         self::assertStringContainsString('list-flags', $result['output']);
         self::assertStringContainsString('dry-run', $result['output']);
+        self::assertStringContainsString('validate', $result['output']);
     }
 
     public function testListFlagsOutputsDetectedFlagsWithoutModifying(): void
@@ -159,6 +160,71 @@ final class ApplicationE2ETest extends TestCase
         self::assertStringContainsString('Nothing flag', $result['output']);
     }
 
+    public function testValidatePassesWithoutModifyingFiles(): void
+    {
+        $this->writeConfig();
+        $this->write(
+            'Valid.php',
+            "<?php\n/** php-del start legacy */\n\$legacy = true;\n/** php-del end legacy */\n"
+        );
+        $original = $this->read('Valid.php');
+
+        $result = $this->runCli(['--validate']);
+
+        self::assertSame(0, $result['exit']);
+        self::assertStringContainsString('validation passed: 1 files, 2 markers', $result['output']);
+        self::assertSame($original, $this->read('Valid.php'));
+    }
+
+    public function testValidateReportsAllMarkerErrorsWithoutModifyingFiles(): void
+    {
+        $this->writeConfig();
+        $this->write('Open.php', "<?php\n// php-del start open\n");
+        $this->write('Invalid.php', "<?php\n// php-del line feature/value\n");
+        $open = $this->read('Open.php');
+        $invalid = $this->read('Invalid.php');
+
+        $result = $this->runCli(['--validate']);
+
+        self::assertSame(1, $result['exit']);
+        self::assertStringContainsString('src/Invalid.php:2:4 [PDEL006]', $result['output']);
+        self::assertStringContainsString('src/Open.php:2:4 [PDEL001]', $result['output']);
+        self::assertStringContainsString('validation failed: 2 errors in 2 files', $result['output']);
+        self::assertSame($open, $this->read('Open.php'));
+        self::assertSame($invalid, $this->read('Invalid.php'));
+    }
+
+    public function testValidateRejectsConflictingOptions(): void
+    {
+        $this->writeConfig();
+
+        $result = $this->runCli(['--validate', '--dry-run']);
+
+        self::assertSame(2, $result['exit']);
+        self::assertStringContainsString('cannot be combined', $result['output']);
+    }
+
+    public function testValidateReportsUnsupportedExtensionAsRuntimeError(): void
+    {
+        $this->writeConfig(['txt']);
+        $this->write('example.txt', '// php-del start legacy');
+
+        $result = $this->runCli(['--validate']);
+
+        self::assertSame(2, $result['exit']);
+        self::assertStringContainsString('src/example.txt:1:1 [PDEL012]', $result['output']);
+    }
+
+    public function testValidateAcceptsEmptyDirectory(): void
+    {
+        $this->writeConfig();
+
+        $result = $this->runCli(['--validate']);
+
+        self::assertSame(0, $result['exit']);
+        self::assertStringContainsString('validation passed: 0 files, 0 markers', $result['output']);
+    }
+
     /**
      * Run the real php-del executable inside the workspace and capture output.
      *
@@ -213,6 +279,11 @@ final class ApplicationE2ETest extends TestCase
         $source = __DIR__ . '/../actual/' . $relative;
         self::assertFileExists($source);
         copy($source, $this->path($destName ?? basename($relative)));
+    }
+
+    private function write(string $name, string $contents): void
+    {
+        file_put_contents($this->path($name), $contents);
     }
 
     private function path(string $name): string

--- a/tests/Unit/ConfigTest.php
+++ b/tests/Unit/ConfigTest.php
@@ -27,4 +27,18 @@ final class ConfigTest extends TestCase
 
         new Config(['dirs' => ['src'], 'extensions' => 'php']);
     }
+
+    public function testDirsMustContainOnlyStrings(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new Config(['dirs' => ['src', 1]]);
+    }
+
+    public function testExtensionsMustContainOnlyStrings(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new Config(['dirs' => ['src'], 'extensions' => ['php', false]]);
+    }
 }

--- a/tests/Unit/MarkerScannerTest.php
+++ b/tests/Unit/MarkerScannerTest.php
@@ -1,0 +1,110 @@
+<?php
+declare(strict_types=1);
+
+use PHPDel\Validation\Marker;
+use PHPDel\Validation\MarkerScanner;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class MarkerScannerTest extends TestCase
+{
+    private MarkerScanner $scanner;
+
+    protected function setUp(): void
+    {
+        $this->scanner = new MarkerScanner();
+    }
+
+    public function testScansPhpCommentsAndIgnoresStrings(): void
+    {
+        $text = <<<'PHP'
+<?php
+$example = 'php-del start string-value';
+/** php-del start legacy */
+$legacy = true;
+/** php-del ignore start */
+$keep = true;
+/** php-del ignore end */
+/** php-del end legacy */
+// php-del line one-line
+PHP;
+
+        $markers = $this->scanner->scan('example.php', $text);
+
+        self::assertSame(
+            [
+                Marker::START,
+                Marker::IGNORE_START,
+                Marker::IGNORE_END,
+                Marker::END,
+                Marker::LINE,
+            ],
+            array_map(static fn (Marker $marker): string => $marker->type, $markers)
+        );
+        self::assertSame('legacy', $markers[0]->flag);
+        self::assertSame(3, $markers[0]->line);
+        self::assertSame(5, $markers[0]->column);
+    }
+
+    #[DataProvider('formatProvider')]
+    public function testScansSupportedCommentFormats(string $file, string $text): void
+    {
+        $markers = $this->scanner->scan($file, $text);
+
+        self::assertCount(2, $markers);
+        self::assertSame(Marker::START, $markers[0]->type);
+        self::assertSame(Marker::END, $markers[1]->type);
+    }
+
+    public static function formatProvider(): iterable
+    {
+        yield 'Blade' => [
+            'example.blade.php',
+            "{{-- php-del start blade --}}\n{{-- php-del end blade --}}\n",
+        ];
+        yield 'CSS' => [
+            'example.css',
+            "/* php-del start css */\n/* php-del end css */\n",
+        ];
+        yield 'SCSS' => [
+            'example.scss',
+            "// php-del start scss\n// php-del end scss\n",
+        ];
+        yield 'Sass' => [
+            'example.sass',
+            "/* php-del start sass */\n/* php-del end sass */\n",
+        ];
+        yield 'Stylus' => [
+            'example.stylus',
+            "// php-del start stylus\n// php-del end stylus\n",
+        ];
+    }
+
+    public function testReportsMalformedMarkers(): void
+    {
+        $text = <<<'PHP'
+<?php
+// php-del start
+// php-del line feature/value
+// php-del something feature
+PHP;
+
+        $markers = $this->scanner->scan('example.php', $text);
+
+        self::assertSame(['PDEL005', 'PDEL006', 'PDEL011'], array_map(
+            static fn (Marker $marker): ?string => $marker->errorId,
+            $markers
+        ));
+    }
+
+    public function testCalculatesUtf8ColumnAndCrLfLine(): void
+    {
+        $text = "<?php\r\n// 日本語 php-del file legacy\r\n";
+
+        $markers = $this->scanner->scan('example.php', $text);
+
+        self::assertCount(1, $markers);
+        self::assertSame(2, $markers[0]->line);
+        self::assertSame(8, $markers[0]->column);
+    }
+}

--- a/tests/Unit/ValidatorTest.php
+++ b/tests/Unit/ValidatorTest.php
@@ -1,0 +1,83 @@
+<?php
+declare(strict_types=1);
+
+use PHPDel\Validation\Marker;
+use PHPDel\Validation\Validator;
+use PHPUnit\Framework\TestCase;
+
+final class ValidatorTest extends TestCase
+{
+    private Validator $validator;
+
+    protected function setUp(): void
+    {
+        $this->validator = new Validator();
+    }
+
+    public function testAcceptsValidNestedBlocksAndIgnorePair(): void
+    {
+        $diagnostics = $this->validator->validate('src/file.php', [
+            $this->marker(Marker::START, 'a', 1),
+            $this->marker(Marker::START, 'b', 2),
+            $this->marker(Marker::IGNORE_START, null, 3),
+            $this->marker(Marker::IGNORE_END, null, 4),
+            $this->marker(Marker::END, 'b', 5),
+            $this->marker(Marker::END, 'a', 6),
+            $this->marker(Marker::LINE, 'line', 7),
+            $this->marker(Marker::FILE, 'file', 8),
+        ]);
+
+        self::assertSame([], $diagnostics);
+    }
+
+    public function testReportsUnmatchedBlockMarkers(): void
+    {
+        $diagnostics = $this->validator->validate('src/file.php', [
+            $this->marker(Marker::START, 'open', 1),
+            $this->marker(Marker::END, 'orphan', 2),
+        ]);
+
+        self::assertSame(['PDEL001', 'PDEL002'], array_map(
+            static fn ($diagnostic): string => $diagnostic->id,
+            $diagnostics
+        ));
+    }
+
+    public function testReportsNestedSameFlagAndCrossingBlocks(): void
+    {
+        $diagnostics = $this->validator->validate('src/file.php', [
+            $this->marker(Marker::START, 'a', 1),
+            $this->marker(Marker::START, 'a', 2),
+            $this->marker(Marker::END, 'a', 3),
+            $this->marker(Marker::START, 'b', 4),
+            $this->marker(Marker::END, 'a', 5),
+            $this->marker(Marker::END, 'b', 6),
+        ]);
+
+        self::assertSame(['PDEL003', 'PDEL004'], array_map(
+            static fn ($diagnostic): string => $diagnostic->id,
+            $diagnostics
+        ));
+    }
+
+    public function testReportsInvalidIgnoreStructures(): void
+    {
+        $diagnostics = $this->validator->validate('src/file.php', [
+            $this->marker(Marker::IGNORE_END, null, 1),
+            $this->marker(Marker::START, 'a', 2),
+            $this->marker(Marker::IGNORE_START, null, 3),
+            $this->marker(Marker::IGNORE_START, null, 4),
+            $this->marker(Marker::END, 'a', 5),
+        ]);
+
+        self::assertSame(
+            ['PDEL008', 'PDEL009', 'PDEL007', 'PDEL007', 'PDEL010'],
+            array_map(static fn ($diagnostic): string => $diagnostic->id, $diagnostics)
+        );
+    }
+
+    private function marker(string $type, ?string $flag, int $line): Marker
+    {
+        return new Marker($type, $flag, $line, 1, $line);
+    }
+}


### PR DESCRIPTION
## Summary

- add a non-destructive `--validate` command that scans all configured files and flags
- report malformed markers with stable diagnostic IDs, relative paths, line and column positions
- return exit code `0` for valid markers, `1` for marker errors, and `2` when validation cannot complete
- add PHPStan 2.x at level max with PHP 8.2 as the analysis baseline
- integrate static analysis into Composer, Task, GitHub Actions, development docs, and release checks

## Why

Previously, malformed markers were generally discovered only when a specific
flag was selected for deletion. Orphaned `end` markers, invalid flags,
crossing blocks, and invalid `ignore` placement could remain undetected. The
new validation mode provides a non-interactive CI check without modifying
files.

PHPStan was added to keep the new validation code and existing source code
type-safe across the supported PHP range. Existing boundary types and failure
handling were tightened instead of introducing a baseline.

## User Impact

Run validation with:

```sh
vendor/bin/php-del --validate
```

Run static analysis with:

```sh
composer analyse
# or
task analyse
```

`--validate` cannot be combined with `--flag`, `--list-flags`, or `--dry-run`.

## Validation

- `composer analyse` at PHPStan level max: no errors
- PHPUnit on PHP 8.2, 8.3, 8.4, and 8.5: 53 tests, 177 assertions
- `composer validate --strict`: passed
- `git diff --check`: passed
