### PR TITLE
[codex] Improve file discovery memory usage

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -102,11 +102,21 @@ class Application
 
         $config = ConfigFactory::make();
 
-        if (!$this->isNonInteractive()) {
-            $this->cli->blink()->dim('Finding flag...');
+        $spinner = null;
+
+        if ($this->shouldShowDynamicOutput()) {
+            $spinner = $this->cli->spinner('Finding flags');
         }
+
         $finder = new Finder($config);
-        $finder->findFlag();
+        $finder->findFlag(function (string $file) use ($spinner): void {
+            $spinner?->advance('Finding flags: ' . basename($file));
+        });
+
+        if ($spinner !== null) {
+            $this->cli->out('');
+        }
+
         $flagList = $finder->getFlagList();
 
         if ($this->isListFlags()) {
@@ -132,7 +142,7 @@ class Application
             return 1;
         }
 
-        foreach ($finder->getTargetFileList() as $file) {
+        foreach ($finder->getTargetFileList($deleteFlag) as $file) {
             try {
                 $text = $this->readFile($file);
                 $deleter = new Deleter($text);
@@ -166,6 +176,14 @@ class Application
         $this->cli->out("End php-del");
 
         return 0;
+    }
+
+    private function shouldShowDynamicOutput(): bool
+    {
+        return !$this->isNonInteractive()
+            && function_exists('stream_isatty')
+            && defined('STDOUT')
+            && stream_isatty(\STDOUT);
     }
 
     private function validate(): int

--- a/src/FileFinder.php
+++ b/src/FileFinder.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace PHPDel;
 
+use Generator;
 use PHPDel\File\AllFileList;
 
 readonly class FileFinder
@@ -13,22 +14,73 @@ readonly class FileFinder
 
     public function find(): AllFileList
     {
-        $files = [];
+        return new AllFileList(iterator_to_array($this->findFiles(), false));
+    }
+
+    /**
+     * @return Generator<int, string>
+     */
+    public function findFiles(): Generator
+    {
+        foreach ($this->rootDirs() as $dir) {
+            yield from $this->rglob($dir, $this->config->getExtensions());
+        }
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function rootDirs(): array
+    {
+        $candidates = [];
+        $roots = [];
 
         foreach ($this->config->getDirs() as $dir) {
-            $directoryFiles = [];
-            $this->rglob(getcwd() . '/' . $dir, $this->config->getExtensions(), $directoryFiles);
-            $files = [...$directoryFiles, ...$files];
+            $path = getcwd() . '/' . $dir;
+            $key = realpath($path);
+            $key = $key === false ? rtrim($path, DIRECTORY_SEPARATOR) : $key;
+            $candidates[$key] = $path . '/*';
         }
 
-        return new AllFileList($files);
+        uksort(
+            $candidates,
+            static function (string $a, string $b): int {
+                $length = strlen($a) <=> strlen($b);
+
+                return $length !== 0 ? $length : strcmp($a, $b);
+            }
+        );
+
+        foreach ($candidates as $key => $path) {
+            if ($this->isNestedRoot($key, $roots)) {
+                continue;
+            }
+
+            $roots[$key] = $path;
+        }
+
+        return array_values($roots);
+    }
+
+    /**
+     * @param array<string, string> $roots
+     */
+    private function isNestedRoot(string $key, array $roots): bool
+    {
+        foreach (array_keys($roots) as $root) {
+            if ($key === $root || str_starts_with($key . DIRECTORY_SEPARATOR, $root . DIRECTORY_SEPARATOR)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**
      * @param list<string> $extensions
-     * @param list<string> $results
+     * @return Generator<int, string>
      */
-    private function rglob(string $dir, array $extensions, array &$results): void
+    private function rglob(string $dir, array $extensions): Generator
     {
         $items = glob($dir);
 
@@ -38,7 +90,7 @@ readonly class FileFinder
 
         foreach ($items as $item) {
             if (is_dir($item)) {
-                $this->rglob($item . '/*', $extensions, $results);
+                yield from $this->rglob($item . '/*', $extensions);
                 continue;
             }
 
@@ -49,7 +101,7 @@ readonly class FileFinder
             $extension = pathinfo($item, PATHINFO_EXTENSION);
 
             if (in_array($extension, $extensions, true)) {
-                $results[] = $item;
+                yield $item;
             }
         }
     }

--- a/src/Finder.php
+++ b/src/Finder.php
@@ -3,26 +3,34 @@ declare(strict_types=1);
 
 namespace PHPDel;
 
-use PHPDel\File\{AllFileList, TargetFileList};
+use PHPDel\File\TargetFileList;
 use PHPDel\Flag\{Flag,FlagList,FlagManager};
 
 class Finder
 {
-    private AllFileList $allFileList;
     private TargetFileList $targetFileList;
     private FlagList $flagList;
+    /** @var array<string, list<string>> */
+    private array $targetFilesByFlag = [];
 
     public function __construct(private readonly Config $config)
     {
-        $this->allFileList = (new FileFinder($this->config))->find();
     }
 
-    public function findFlag(): void
+    /**
+     * @param (callable(string): void)|null $onFile
+     */
+    public function findFlag(?callable $onFile = null): void
     {
         $flagManager = new FlagManager();
         $targetFiles = [];
+        $this->targetFilesByFlag = [];
 
-        foreach ($this->allFileList as $file) {
+        foreach ((new FileFinder($this->config))->findFiles() as $file) {
+            if ($onFile !== null) {
+                $onFile($file);
+            }
+
             $text = file_get_contents($file);
 
             if ($text === false) {
@@ -41,17 +49,27 @@ class Finder
             }
 
             $targetFiles[] = $file;
+            $fileFlags = [];
 
             foreach ($matches['flag'] as $flag) {
                 $flagManager->add(new Flag($flag));
+                $fileFlags[$flag] = true;
+            }
+
+            foreach (array_keys($fileFlags) as $flag) {
+                $this->targetFilesByFlag[$flag][] = $file;
             }
         }
         $this->flagList = $flagManager->getFlagList();
         $this->targetFileList = new TargetFileList($targetFiles);
     }
 
-    public function getTargetFileList(): TargetFileList
+    public function getTargetFileList(?string $flag = null): TargetFileList
     {
+        if ($flag !== null) {
+            return new TargetFileList($this->targetFilesByFlag[$flag] ?? []);
+        }
+
         return $this->targetFileList;
     }
 

--- a/src/Validation/ValidationRunner.php
+++ b/src/Validation/ValidationRunner.php
@@ -18,12 +18,12 @@ readonly class ValidationRunner
 
     public function run(): ValidationResult
     {
-        $files = iterator_to_array((new FileFinder($this->config))->find(), false);
-        sort($files, SORT_STRING);
         $diagnostics = [];
+        $fileCount = 0;
         $markerCount = 0;
 
-        foreach ($files as $file) {
+        foreach ((new FileFinder($this->config))->findFiles() as $file) {
+            ++$fileCount;
             $path = $this->relativePath($file);
             $text = file_get_contents($file);
 
@@ -56,7 +56,7 @@ readonly class ValidationRunner
             }
         }
 
-        return new ValidationResult($diagnostics, count($files), $markerCount);
+        return new ValidationResult($diagnostics, $fileCount, $markerCount);
     }
 
     private function relativePath(string $path): string

--- a/tests/Unit/FinderTest.php
+++ b/tests/Unit/FinderTest.php
@@ -15,6 +15,11 @@ final class FinderTest extends TestCase
 
         $targetList = $finder->getTargetFileList();
         self::assertCount(13, $targetList);
+        self::assertCount(4, $finder->getTargetFileList('flag_a'));
+        self::assertCount(1, $finder->getTargetFileList('flag_b'));
+        self::assertCount(4, $finder->getTargetFileList('error-flag'));
+        self::assertCount(4, $finder->getTargetFileList('delete_flag'));
+        self::assertCount(0, $finder->getTargetFileList('unknown'));
 
         $flagList = $finder->getFlagList();
         self::assertSame('flag_a', $flagList->offsetGet('flag_a')->get());
@@ -26,5 +31,18 @@ final class FinderTest extends TestCase
         self::assertSame(8, $flagList->offsetGet('error-flag')->count());
         self::assertSame('delete_flag', $flagList->offsetGet('delete_flag')->get());
         self::assertSame(4, $flagList->offsetGet('delete_flag')->count());
+    }
+
+    public function testFinderDoesNotReadDuplicateDirsTwice(): void
+    {
+        $config = new Config(['dirs' => ['tests/actual/flag_b', 'tests/actual']]);
+        $finder = new Finder($config);
+        $finder->findFlag();
+
+        self::assertCount(7, $finder->getTargetFileList());
+
+        $flagList = $finder->getFlagList();
+        self::assertSame('flag_b', $flagList->offsetGet('flag_b')->get());
+        self::assertSame(3, $flagList->offsetGet('flag_b')->count());
     }
 }


### PR DESCRIPTION
## Summary

- Stream file discovery through FileFinder::findFiles() so Finder and validation no longer need to retain every candidate path before scanning.
- Deduplicate overlapping configured root directories before recursive scanning.
- Track files per detected flag so normal deletion only revisits files relevant to the selected flag.
- Replace the interactive Finding flag output with a TTY-only CLImate spinner.

## Validation

- task test
- task analyse