### PR TITLE
[codex] Improve loading indicators

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -84,11 +84,6 @@ class Application
         return $this->cli->arguments->defined('flag');
     }
 
-    private function isNonInteractive(): bool
-    {
-        return $this->isListFlags() || $this->hasSelectedFlagArgument() || $this->isValidate();
-    }
-
     public function main(): int
     {
         if ($this->help()) {
@@ -109,8 +104,8 @@ class Application
         }
 
         $finder = new Finder($config);
-        $finder->findFlag(function (string $file) use ($spinner): void {
-            $spinner?->advance('Finding flags: ' . basename($file));
+        $finder->findFlag(function (string $_path) use ($spinner): void {
+            $spinner?->advance();
         });
 
         if ($spinner !== null) {
@@ -180,8 +175,7 @@ class Application
 
     private function shouldShowDynamicOutput(): bool
     {
-        return !$this->isNonInteractive()
-            && function_exists('stream_isatty')
+        return function_exists('stream_isatty')
             && defined('STDOUT')
             && stream_isatty(\STDOUT);
     }
@@ -195,11 +189,29 @@ class Application
             return 2;
         }
 
+        $spinner = null;
+
+        if ($this->shouldShowDynamicOutput()) {
+            $spinner = $this->cli->spinner('Validating markers');
+        }
+
         try {
-            $result = (new ValidationRunner(ConfigFactory::make()))->run();
+            $result = (new ValidationRunner(ConfigFactory::make()))->run(
+                function (string $_path) use ($spinner): void {
+                    $spinner?->advance();
+                }
+            );
         } catch (\Throwable $throwable) {
+            if ($spinner !== null) {
+                $this->cli->out('');
+            }
+
             $this->cli->error('[ERROR] ' . $throwable->getMessage());
             return 2;
+        }
+
+        if ($spinner !== null) {
+            $this->cli->out('');
         }
 
         foreach ($result->diagnostics as $diagnostic) {

--- a/src/FileFinder.php
+++ b/src/FileFinder.php
@@ -18,12 +18,13 @@ readonly class FileFinder
     }
 
     /**
+     * @param (callable(string): void)|null $onPath
      * @return Generator<int, string>
      */
-    public function findFiles(): Generator
+    public function findFiles(?callable $onPath = null): Generator
     {
         foreach ($this->rootDirs() as $dir) {
-            yield from $this->rglob($dir, $this->config->getExtensions());
+            yield from $this->rglob($dir, $this->config->getExtensions(), $onPath);
         }
     }
 
@@ -78,9 +79,10 @@ readonly class FileFinder
 
     /**
      * @param list<string> $extensions
+     * @param (callable(string): void)|null $onPath
      * @return Generator<int, string>
      */
-    private function rglob(string $dir, array $extensions): Generator
+    private function rglob(string $dir, array $extensions, ?callable $onPath): Generator
     {
         $items = glob($dir);
 
@@ -89,8 +91,12 @@ readonly class FileFinder
         }
 
         foreach ($items as $item) {
+            if ($onPath !== null) {
+                $onPath($item);
+            }
+
             if (is_dir($item)) {
-                yield from $this->rglob($item . '/*', $extensions);
+                yield from $this->rglob($item . '/*', $extensions, $onPath);
                 continue;
             }
 

--- a/src/Finder.php
+++ b/src/Finder.php
@@ -18,19 +18,15 @@ class Finder
     }
 
     /**
-     * @param (callable(string): void)|null $onFile
+     * @param (callable(string): void)|null $onPath
      */
-    public function findFlag(?callable $onFile = null): void
+    public function findFlag(?callable $onPath = null): void
     {
         $flagManager = new FlagManager();
         $targetFiles = [];
         $this->targetFilesByFlag = [];
 
-        foreach ((new FileFinder($this->config))->findFiles() as $file) {
-            if ($onFile !== null) {
-                $onFile($file);
-            }
-
+        foreach ((new FileFinder($this->config))->findFiles($onPath) as $file) {
             $text = file_get_contents($file);
 
             if ($text === false) {

--- a/src/Validation/ValidationRunner.php
+++ b/src/Validation/ValidationRunner.php
@@ -16,13 +16,16 @@ readonly class ValidationRunner
     ) {
     }
 
-    public function run(): ValidationResult
+    /**
+     * @param (callable(string): void)|null $onPath
+     */
+    public function run(?callable $onPath = null): ValidationResult
     {
         $diagnostics = [];
         $fileCount = 0;
         $markerCount = 0;
 
-        foreach ((new FileFinder($this->config))->findFiles() as $file) {
+        foreach ((new FileFinder($this->config))->findFiles($onPath) as $file) {
             ++$fileCount;
             $path = $this->relativePath($file);
             $text = file_get_contents($file);


### PR DESCRIPTION
## Summary

- Show the loading spinner for --list-flags, --flag, and --validate when stdout is a TTY.
- Advance the spinner during directory traversal so wide scans do not appear stalled before matching files are found.
- Keep spinner labels stable instead of rendering changing file or class names.
- Preserve quiet non-TTY output for tests and automation.

## Why

Large configured directories can take time to scan. Without a visible indicator, commands such as --list-flags and --validate can look stuck even though discovery is still running.

## Validation

- task test
- task analyse